### PR TITLE
fix org.mapleir.app.service.ClassTree#getAllBranches

### DIFF
--- a/org.mapleir.app-services/src/main/java/org/mapleir/app/service/ClassTree.java
+++ b/org.mapleir.app-services/src/main/java/org/mapleir/app/service/ClassTree.java
@@ -129,7 +129,7 @@ public class ClassTree extends FastDirectedGraph<ClassNode, InheritanceEdge> {
 				queue.addAll(getAllChildren(next));
 			}
 		}
-		queue.add(cn);
+		queue.addAll(results);
 		while (!queue.isEmpty()) {
 			ClassNode next = queue.remove();
 			if (results.add(next) && next != rootNode) {


### PR DESCRIPTION
For example, we have three classes: 'class Abst', 'interface Inte', 'class Top extends Abst implements Inte' If call this with 'Inte', it should return all these classes and java.lang.Object